### PR TITLE
(BOLT-GH-1433) Add apply_settings to apply_catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.2.0
+
+**Features**
+- Support for `apply_settings` configurable in bolt.yaml.
+
 ## Release 0.1.0
 
 **Features**

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-apply_helpers",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Puppet, Inc.",
   "summary": "Helper libraries for Bolt Apply functionality",
   "license": "Apache-2.0",

--- a/tasks/apply_catalog.json
+++ b/tasks/apply_catalog.json
@@ -13,6 +13,11 @@
       "description": "Plugin bundle to use when applying resources",
       "type": "String",
       "sensitive": true
+    },
+    "apply_settings": {
+      "description": "Puppet Settings to use during catalog application for example `show_diff`",
+      "type": "Optional[Hash]",
+      "sensitive": true
     }
   }
 }

--- a/tasks/apply_catalog.rb
+++ b/tasks/apply_catalog.rb
@@ -29,6 +29,11 @@ Puppet[:report] = false
 # Make sure to apply the catalog
 Puppet[:noop] = args['_noop'] || false
 
+apply_settings = args['apply_settings'] || {}
+apply_settings.each do |setting, value|
+  Puppet[setting.to_sym] = value
+end
+
 Puppet[:default_file_terminus] = :file_server
 
 exit_code = 0


### PR DESCRIPTION
This commit updates the apply_catalog task to honor the apply_settings exposed by bolt in GH-1433. Without this addition the task errors bc of the unexpected apply_settings task argument with bolt >= 1.48.0.