### PR TITLE
(packaging) Pin blacksmith to enable default module ship job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.2.1
+
+**Bug fix**
+- Packaging/shipping automation updates require change to source code. Bump z without changing module code.
+
 ## Release 0.2.0
 
 **Features**

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,10 @@
+
+# frozen_string_literal: true
+
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 def location_for(place_or_version, fake_version = nil)
-  if place_or_version =~ %r{\A(git[:@][^#]*)#(.*)}
+  if place_or_version =~ /\A(git[:@][^#]*)#(.*)/
     [fake_version, { git: Regexp.last_match(1), branch: Regexp.last_match(2), require: false }].compact
   elsif place_or_version =~ %r{\Afile:\/\/(.*)}
     ['>= 0', { path: File.expand_path(Regexp.last_match(1)), require: false }]
@@ -19,4 +22,6 @@ group :development do
   gem "puppet-module-posix-default-r#{minor_version}", require: false, platforms: [:ruby]
   gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
   gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])
+  # Pin puppet blacksmith to avoid failures in forge module push job
+  gem "puppet-blacksmith", "4.1.2"
 end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-apply_helpers",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Puppet, Inc.",
   "summary": "Helper libraries for Bolt Apply functionality",
   "license": "Apache-2.0",


### PR DESCRIPTION
This commit pins puppet-blacksmith to maintain compatability with module shipping job. This requires a z bump because this bug was discovered after tagging/trying to release a new y.