### PR TITLE
(maint) Update query_resources task metadata

### DIFF
--- a/tasks/query_resources.json
+++ b/tasks/query_resources.json
@@ -15,7 +15,7 @@
     },
     "resources": {
       "description": " A resource type or instance, or an array of such",
-      "type": "Array[Variant[String, Type[Resource]]]"
+      "type": "Array[String]"
     }
   }
 }


### PR DESCRIPTION
The resources parameter is expected to be an array with type string (the calling code in bolt ensures the resource types are serialized).